### PR TITLE
Add README for Informer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Informer
+
+This repository contains a PyTorch implementation of the **Informer** architecture for long sequence forecasting. The code is auto-generated from the notebook [nbs/models.informer.ipynb](nbs/models.informer.ipynb).
+
+Informer alleviates the heavy computational cost of vanilla Transformers using three key ideas:
+
+1. **ProbSparse self-attention** with $O(L\log L)$ time and memory complexity.
+2. A **self-attention distilling process** that focuses on important elements of long sequences.
+3. An **MLP multi-step decoder** to predict long horizons in a single forward pass.
+
+A more detailed explanation is available in the class docstring inside [`informer.py`](informer.py).
+
+## Requirements
+
+- [neuralforecast](https://github.com/Nixtla/neuralforecast)
+- torch
+- numpy
+
+Install them with `pip`:
+
+```bash
+pip install neuralforecast torch numpy
+```
+
+## Quick example
+
+```python
+from informer import Informer
+
+# minimal initialization
+model = Informer(
+    h=24,            # forecast horizon
+    input_size=168,  # history length
+)
+```
+
+This class can then be used with the **neuralforecast** training utilities.


### PR DESCRIPTION
## Summary
- document auto-generated Informer implementation
- list minimal requirements
- show small usage example

## Testing
- `python -m py_compile informer.py`


------
https://chatgpt.com/codex/tasks/task_e_684ca262b2f483218dfebef4bbb1aae1