### PR TITLE
Add docstrings to Informer modules

### DIFF
--- a/neuralforecast/common/_modules.py
+++ b/neuralforecast/common/_modules.py
@@ -2,6 +2,22 @@ import torch
 from torch import nn
 
 class DataEmbedding(nn.Module):
+    """Embed input series and optional exogenous features.
+
+    Parameters
+    ----------
+    c_in : int
+        Number of features of the main time series.
+    exog_input_size : int, optional
+        Size of the exogenous inputs concatenated to ``x``.
+    hidden_size : int, optional
+        Dimension of the resulting embedding.
+    pos_embedding : bool, optional
+        Unused flag kept for API compatibility.
+    dropout : float, optional
+        Dropout rate, currently unused.
+    """
+
     def __init__(self, c_in, exog_input_size=0, hidden_size=16, pos_embedding=True, dropout=0.1):
         super().__init__()
         self.proj = nn.Linear(c_in + exog_input_size, hidden_size)
@@ -11,6 +27,18 @@ class DataEmbedding(nn.Module):
         return self.proj(x)
 
 class AttentionLayer(nn.Module):
+    """Thin wrapper around an attention module.
+
+    Parameters
+    ----------
+    attention : nn.Module
+        Module implementing the attention operation.
+    d_model : int
+        Embedding dimension of the model (kept for compatibility).
+    n_heads : int
+        Number of attention heads (kept for compatibility).
+    """
+
     def __init__(self, attention, d_model, n_heads):
         super().__init__()
         self.attention = attention
@@ -19,6 +47,22 @@ class AttentionLayer(nn.Module):
         return self.attention(queries, keys, values, attn_mask)
 
 class TransEncoderLayer(nn.Module):
+    """Single encoder block based on self-attention.
+
+    Parameters
+    ----------
+    attn_layer : nn.Module
+        Attention layer applied to the input sequence.
+    d_model : int
+        Embedding dimension of the model.
+    conv_hidden_size : int
+        Size of intermediate convolutional layers (unused here).
+    dropout : float, optional
+        Dropout rate used inside the layer (unused).
+    activation : str, optional
+        Name of the activation function (unused).
+    """
+
     def __init__(self, attn_layer, d_model, conv_hidden_size, dropout=0.1, activation="gelu"):
         super().__init__()
         self.attn_layer = attn_layer
@@ -28,6 +72,18 @@ class TransEncoderLayer(nn.Module):
         return x, None
 
 class TransEncoder(nn.Module):
+    """Stack of encoder layers used by Informer.
+
+    Parameters
+    ----------
+    layers : list[nn.Module]
+        Sequence of :class:`TransEncoderLayer` objects.
+    conv_layers : list[nn.Module], optional
+        Optional convolutional layers for distillation.
+    norm_layer : nn.Module, optional
+        Normalization layer applied after the stack.
+    """
+
     def __init__(self, layers, conv_layers=None, norm_layer=None):
         super().__init__()
         self.layers = nn.ModuleList(layers)
@@ -37,6 +93,24 @@ class TransEncoder(nn.Module):
         return x, None
 
 class TransDecoderLayer(nn.Module):
+    """Decoder block with self- and cross-attention.
+
+    Parameters
+    ----------
+    self_attn_layer : nn.Module
+        Attention layer applied to the decoder inputs.
+    cross_attn_layer : nn.Module
+        Attention layer attending to the encoder outputs (unused).
+    d_model : int
+        Embedding dimension of the model.
+    conv_hidden_size : int
+        Size of intermediate convolutional layers (unused).
+    dropout : float, optional
+        Dropout rate for the layer (unused).
+    activation : str, optional
+        Name of the activation function (unused).
+    """
+
     def __init__(self, self_attn_layer, cross_attn_layer, d_model, conv_hidden_size, dropout=0.1, activation="gelu"):
         super().__init__()
         self.self_attn_layer = self_attn_layer
@@ -46,6 +120,18 @@ class TransDecoderLayer(nn.Module):
         return x
 
 class TransDecoder(nn.Module):
+    """Stack of decoder layers producing the final predictions.
+
+    Parameters
+    ----------
+    layers : list[nn.Module]
+        Sequence of :class:`TransDecoderLayer` modules.
+    norm_layer : nn.Module, optional
+        Optional normalization applied after the stack.
+    projection : nn.Module, optional
+        Linear projection applied to the decoder output.
+    """
+
     def __init__(self, layers, norm_layer=None, projection=None):
         super().__init__()
         self.layers = nn.ModuleList(layers)


### PR DESCRIPTION
## Summary
- document core modules used by Informer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6868458c517c832199307b712e222110